### PR TITLE
Fix login button link on register page

### DIFF
--- a/app/templates/registration/registration.html
+++ b/app/templates/registration/registration.html
@@ -85,7 +85,7 @@
               SIGN UP <span class="material-icons"> arrow_right_alt </span>
             </button>
             <center>
-              <p>Already have an account? <a href="login.html">Login</a></p>
+              <p>Already have an account? <a href="{% url "login" %}">Login</a></p>
             </center>
           </div>
         </center>


### PR DESCRIPTION
Fixes #7

Updates the login link on the registration page to use Django's template URL tag instead of a hardcoded file path.